### PR TITLE
29 createpick color pallette from mui

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -5,12 +5,29 @@ import store from './app/store.js';
 import App from './app/App';
 import { BrowserRouter as Router } from 'react-router-dom';
 
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: '#90caf9',
+      dark: '#1976d2'
+    },
+    secondary: {
+      main: '#b0bec5',
+      dark: '#607d8b'
+    },
+  },
+});
+
 const root = createRoot(document.getElementById('app'));
 
 root.render(
   <Router>
     <Provider store={store}>
+      <ThemeProvider theme={theme}>
       <App />
+      </ThemeProvider>
     </Provider>
   </Router>
 );

--- a/client/index.js
+++ b/client/index.js
@@ -26,7 +26,7 @@ root.render(
   <Router>
     <Provider store={store}>
       <ThemeProvider theme={theme}>
-      <App />
+        <App />
       </ThemeProvider>
     </Provider>
   </Router>


### PR DESCRIPTION
Added primary (blue) and secondary(bluegrey) theme colors. Please let me know if you want to change colors (see all colors here: https://mui.com/material-ui/customization/color/)

Example below (will revert ProductCard.js changes back to original so to avoid merge conflicts):

<img width="600" alt="Screenshot 2023-01-12 at 1 13 33 PM" src="https://user-images.githubusercontent.com/113927218/212147002-169f7981-b262-4c95-94c9-cba57412083f.png">
<img width="670" alt="Screenshot 2023-01-12 at 1 13 39 PM" src="https://user-images.githubusercontent.com/113927218/212147013-7ab5a191-fb44-4408-80cd-7c2fcef09313.png">

![Screenshot 2023-01-12 at 1 13 25 PM](https://user-images.githubusercontent.com/113927218/212147032-283a2908-1011-426f-91ab-51fa3159f93a.png)

