### PR TITLE
made all products line up and changed sizing of single product page s…

### DIFF
--- a/client/features/products/ProductsCard.js
+++ b/client/features/products/ProductsCard.js
@@ -25,6 +25,7 @@ const ProductsCard = ({
       sx={{
         display: "flex",
         flexDirection: "column",
+        width: "100%",
         height: "100%",
         textAlign: "center",
         alignItems: "center",
@@ -39,7 +40,11 @@ const ProductsCard = ({
       >
         <CardMedia
           component="img"
-          sx={{ width: 200 }}
+          sx={{
+            width: "200px",
+            height: "150px",
+            objectFit: "scale-down",
+          }}
           image={imageURL[0]}
           alt="Sneaker Photo"
         />

--- a/client/features/singleProduct/SingleProduct.js
+++ b/client/features/singleProduct/SingleProduct.js
@@ -37,7 +37,7 @@ const SingleProduct = () => {
         <Grid
           container
           spacing={5}
-          style={{ maxWidth: 1100, margin: "0 auto" }}
+          style={{ width: "100%", height: "100%", overflow: "auto" }}
         >
           <Grid item sm={1}>
             <ImageGrid


### PR DESCRIPTION
changed sizing of single product page so text isn't lined up all the way to left:
<img width="1013" alt="beforeChangeProducts" src="https://user-images.githubusercontent.com/47368976/213389344-d9cdfe38-3076-4fb8-b325-6ef4237a6fa9.png">
<img width="1014" alt="afterChangeProducts" src="https://user-images.githubusercontent.com/47368976/213389348-197658d2-3942-46d0-8877-5f744765b21a.png">
<img width="1072" alt="afterSingleProductChange" src="https://user-images.githubusercontent.com/47368976/213389577-1cbd1ee8-fcb2-43d6-b8ac-78e8f5dd6be7.png">
<img width="1099" alt="beforeSingleProductChange" src="https://user-images.githubusercontent.com/47368976/213389580-dc1409be-2670-4cba-b676-7214dbbbb287.png">
